### PR TITLE
Fixed random linker error 

### DIFF
--- a/Sources/CwlCatchExceptionSupport/CwlCatchException.m
+++ b/Sources/CwlCatchExceptionSupport/CwlCatchException.m
@@ -23,7 +23,7 @@
 #if !SWIFT_PACKAGE && NON_SWIFT_PACKAGE
 __attribute__((visibility("hidden")))
 #endif
-NSException* catchExceptionOfKind(Class __nonnull type, void (^ __nonnull inBlock)(void)) {
+NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ __nonnull inBlock)(void)) {
 	@try {
 		inBlock();
 	} @catch (NSException *exception) {


### PR DESCRIPTION
Fixed error:
```
Undefined symbols for architecture x86_64:
  "_catchExceptionOfKind", referenced from:
CwlCatchException.(catchReturnTypeConverter in _841BEC3F94220F0DFD4EA4E9DDB3DC93)<A where A: __C.NSException>(_: A.Type, block: () -> ()) -> A? in
```