### PR TITLE
Non-escaping block

### DIFF
--- a/Sources/CwlCatchException/CwlCatchException.swift
+++ b/Sources/CwlCatchException/CwlCatchException.swift
@@ -24,12 +24,12 @@ import Foundation
 import CwlCatchExceptionSupport
 #endif
 
-private func catchReturnTypeConverter<T: NSException>(_ type: T.Type, block: @escaping () -> Void) -> T? {
+private func catchReturnTypeConverter<T: NSException>(_ type: T.Type, block: () -> Void) -> T? {
 	return catchExceptionOfKind(type, block) as? T
 }
 
 extension NSException {
-	public static func catchException(in block: @escaping () -> Void) -> Self? {
+	public static func catchException(in block: () -> Void) -> Self? {
 		return catchReturnTypeConverter(self, block: block)
 	}
 }

--- a/Sources/CwlCatchExceptionSupport/CwlCatchException.m
+++ b/Sources/CwlCatchExceptionSupport/CwlCatchException.m
@@ -20,7 +20,7 @@
 
 #import "CwlCatchException.h"
 
-NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ __nonnull inBlock)(void)) {
+NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ NS_NOESCAPE __nonnull inBlock)(void)) {
 	@try {
 		inBlock();
 	} @catch (NSException *exception) {

--- a/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h
+++ b/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h
@@ -20,4 +20,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ __nonnull inBlock)(void));
+NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ NS_NOESCAPE __nonnull inBlock)(void));


### PR DESCRIPTION
Changes the block signature to indicate that it does not escape