### PR TITLE
NSException → Error conversion

### DIFF
--- a/Sources/CwlCatchException/CwlCatchException.swift
+++ b/Sources/CwlCatchException/CwlCatchException.swift
@@ -24,12 +24,12 @@ import Foundation
 import CwlCatchExceptionSupport
 #endif
 
-private func catchReturnTypeConverter<T: NSException>(_ type: T.Type, block: @escaping () -> Void) -> T? {
+private func catchReturnTypeConverter<T: NSException>(_ type: T.Type, block: () -> Void) -> T? {
 	return catchExceptionOfKind(type, block) as? T
 }
 
 extension NSException {
-	public static func catchException(in block: @escaping () -> Void) -> Self? {
+	public static func catchException(in block: () -> Void) -> Self? {
 		return catchReturnTypeConverter(self, block: block)
 	}
 }

--- a/Sources/CwlCatchExceptionSupport/CwlCatchException.m
+++ b/Sources/CwlCatchExceptionSupport/CwlCatchException.m
@@ -20,7 +20,7 @@
 
 #import "CwlCatchException.h"
 
-NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ __nonnull inBlock)(void)) {
+NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ NS_NOESCAPE __nonnull inBlock)(void)) {
 	@try {
 		inBlock();
 	} @catch (NSException *exception) {

--- a/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h
+++ b/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h
@@ -20,4 +20,4 @@
 
 #import <Foundation/Foundation.h>
 
-NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ __nonnull inBlock)(void));
+NSException* __nullable catchExceptionOfKind(Class __nonnull type, void (^ NS_NOESCAPE __nonnull inBlock)(void));


### PR DESCRIPTION
_Built upon PR #4_ 
Closes Issue #1

This PR adds a method for converting a thrown `NSException` into a thrown `Error`. Which bridges the gap between `NSExceptions` and [Swift's Error handing](https://docs.swift.org/swift-book/LanguageGuide/ErrorHandling.html).

Take this example where `JSONSerialization.data` can both throw an `Error` or raise an `NSException`. 
Previously, a `do/try/catch` needed to be within the `catchException` block and the `value/error`  variables needed to be captured within the block:

```swift
func safelyEncodeJSON() throws -> Data  {
    var value: Data?
    var error: Error?

    let exception = NSException.catchException {
        do {
            value = try JSONSerialization.data(withJSONObject: ["bad": Locale.current], options: [])
        } catch let thrownError {
            error = thrownError
        }
    }

    if let exception = exception {
        throw ExceptionError(exception)
    } else if let error = error {
        throw error
    } else {
        return value!
    }
}
```

With the new `catchAsError` method, that boilerplate is unnecessary. `NSExceptions` are thrown as `ExceptionErrors` and 
values from within the `catchAsError` block can be returned directly
```swift
func safelyEncodeJSON() throws -> Data  {
    return try NSException.catchAsError {
        return try JSONSerialization.data(withJSONObject: ["bad": Locale.current], options: [])
    }
}
```