### PR TITLE
Addressing build warning about NSException not conforming to 'Sendable'

### DIFF
--- a/CwlCatchException.podspec
+++ b/CwlCatchException.podspec
@@ -5,11 +5,14 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/mattgallagher/CwlCatchException'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
   s.author       = 'Matt Gallagher'
-  s.source       = { :git => 'https://github.com/mattgallagher/CwlCatchException.git', :tag => s.version.to_s }
+  s.source       = {
+                    :git => 'https://github.com/mattgallagher/CwlCatchException.git',
+                    :tag => s.version.to_s
+                   }
   
   s.source_files = 'Sources/CwlCatchException/**/*.swift'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.10'
 
   s.swift_version = '5.0'

--- a/CwlCatchExceptionSupport.podspec
+++ b/CwlCatchExceptionSupport.podspec
@@ -5,10 +5,13 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/mattgallagher/CwlCatchException'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
   s.author       = 'Matt Gallagher'
-  s.source       = { :git => 'https://github.com/mattgallagher/CwlCatchException.git', :tag => s.version.to_s }
+  s.source       = {
+                    :git => 'https://github.com/mattgallagher/CwlCatchException.git',
+                    :tag => s.version.to_s
+                   }
   
   s.source_files = 'Sources/CwlCatchExceptionSupport/**/*.{h,m}'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.10'
 end

--- a/Sources/CwlCatchException/CwlCatchException.swift
+++ b/Sources/CwlCatchException/CwlCatchException.swift
@@ -43,10 +43,15 @@ public func catchExceptionAsError<Output>(in block: (() throws -> Output)) throw
 
 	if let exception = exception {
 		throw ExceptionError(exception)
-	} else {
-		return try result!.get()
 	}
+    
+	return try result!.get()
 }
+
+/**
+ Adding conformance so that ExceptionError is fully Sendable as part of CustomNSError
+ */
+extension NSException: @unchecked Sendable { }
 
 public struct ExceptionError: CustomNSError {
 	public let exception: NSException

--- a/Tests/CwlCatchExceptionTests/CwlCatchExceptionTests.swift
+++ b/Tests/CwlCatchExceptionTests/CwlCatchExceptionTests.swift
@@ -71,6 +71,19 @@ class CatchExceptionTests: XCTestCase {
 		}
 	}
 
+    func test_when_exception_raised_then_catchexceptionaserror_throws_exceptionerror_no_userinfo() throws {
+        let exception = TestException(userInfo: nil)
+        do {
+            try catchExceptionAsError {
+                exception.raise()
+            }
+        } catch let error as ExceptionError {
+            XCTAssertEqual(error.exception, exception)
+            XCTAssertNotNil(error.errorUserInfo)
+            XCTAssertTrue(error.errorUserInfo.isEmpty)
+        }
+    }
+
 	func test_when_error_thrown_then_catchexceptionaserror_rethrows() throws {
 		let urlError = URLError(.badURL)
 		do {


### PR DESCRIPTION
Testing
* Increased code coverage to 100% by testing creation of an ExceptionError for an exception with no userData

Cocoapods
* Increased minimum iOS version to 12.0

Addressing Issue #7