### PR TITLE
[Issue 9] Address build warnings with Xcode 16

### DIFF
--- a/CwlCatchException.podspec
+++ b/CwlCatchException.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'CwlCatchException'
-  s.version      = '2.2.0'
+  s.version      = '2.2.1'
   s.summary      = 'A simple Swift wrapper around Objective-C `@try`/`@catch` statements.'
   s.homepage     = 'https://github.com/mattgallagher/CwlCatchException'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.5'
 
-  s.dependency 'CwlCatchExceptionSupport', '~> 2.2.0'
+  s.dependency 'CwlCatchExceptionSupport', '~> 2.2.1'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/**/*.swift'

--- a/CwlCatchExceptionSupport.podspec
+++ b/CwlCatchExceptionSupport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'CwlCatchExceptionSupport'
-  s.version      = '2.2.0'
+  s.version      = '2.2.1'
   s.summary      = 'Objective-C internal library used by CwlCatchException'
   s.homepage     = 'https://github.com/mattgallagher/CwlCatchException'
   s.license      = { :file => 'LICENSE.txt', :type => 'ISC' }

--- a/Sources/CwlCatchException/CwlCatchException.swift
+++ b/Sources/CwlCatchException/CwlCatchException.swift
@@ -49,7 +49,12 @@ public func catchExceptionAsError<Output>(in block: (() throws -> Output)) throw
 }
 
 // Adding conformance so that ExceptionError is fully Sendable as part of CustomNSError
+#if compiler(<6.0)
+extension NSException: @unchecked Sendable { }
+#else
+// @retroactive not available until Xcode 16 / Swift 6
 extension NSException: @unchecked @retroactive Sendable { }
+#endif
 
 public struct ExceptionError: CustomNSError {
 	public let exception: NSException

--- a/Sources/CwlCatchException/CwlCatchException.swift
+++ b/Sources/CwlCatchException/CwlCatchException.swift
@@ -49,7 +49,7 @@ public func catchExceptionAsError<Output>(in block: (() throws -> Output)) throw
 }
 
 // Adding conformance so that ExceptionError is fully Sendable as part of CustomNSError
-extension NSException: @unchecked Sendable { }
+extension NSException: @unchecked @retroactive Sendable { }
 
 public struct ExceptionError: CustomNSError {
 	public let exception: NSException

--- a/Tests/CwlCatchExceptionTests/CwlCatchExceptionTests.swift
+++ b/Tests/CwlCatchExceptionTests/CwlCatchExceptionTests.swift
@@ -24,7 +24,7 @@ import CwlCatchException
 import CwlCatchExceptionSupport
 #endif
 
-class TestException: NSException {
+class TestException: NSException, @unchecked Sendable {
 	static var name: String = "com.cocoawithlove.TestException"
 	init(userInfo: [AnyHashable: Any]? = nil) {
 		super.init(name: NSExceptionName(rawValue: TestException.name), reason: nil, userInfo: userInfo)


### PR DESCRIPTION
Addressing build warnings with Xcode 16.

Resolves Issue #9 

Increasing version numbers as a result, so it can be easily released.